### PR TITLE
feat: add the expo web platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ const App = () => {
 
 ## Run the sample app
 
+> [!Note]
+> In terms of the redirect URI scheme, different platforms have different requirements.
+>
+> - For native platforms, a Private-Use native URI scheme is required. See [OAuth2 spec](https://datatracker.ietf.org/doc/html/rfc8252#section-8.4) for more details.
+> - For web platforms (SPA), an `http(s)//` scheme is required.
+>
+> You may need to register different applications in the Logto dashboard for different platforms. Make sure to configure the correct `redirectUri` and `clientId` for different platforms.
+
 ### Replace the `appId` and `endpoint` in `App.tsx` with your own Logto settings.
 
 ```tsx
@@ -107,14 +115,6 @@ pnpm dev:web
 > This SDK is not compatible with "Expo Go" sandbox on Android.
 > Expo Go app by default uses `exp://` scheme for deep linking, which is not a valid private native scheme. See [OAuth2 spec](https://datatracker.ietf.org/doc/html/rfc8252#section-8.4) for more details.
 > For Android, Use [development-build](https://docs.expo.dev/develop/development-builds/introduction/) to test this SDK
-
-> [!Note]
-> In terms of the redirect URI scheme, different platforms have different requirements.
->
-> - For native platforms, a Private-Use native URI scheme is required. See [OAuth2 spec](https://datatracker.ietf.org/doc/html/rfc8252#section-8.4) for more details.
-> - For web platforms (SPA), an `http(s)//` scheme is required.
->
-> You may need to register different applications in the Logto dashboard for different platforms. Make sure to configure the correct `redirectUri` and `clientId` for different platforms.
 
 ### Build and run native package
 

--- a/README.md
+++ b/README.md
@@ -79,18 +79,45 @@ const endpoint = "YOUR_LOGTO_ENDPOINT";
 const appId = "YOUR_APP_ID";
 ```
 
-### Run using Expo Go
+### Development using Expo Go
 
-> [!Caution]
-> This SDK is not compatible with "Expo Go" sandbox on Android.
-> Under the hood, this SDK uses `ExpoAuthSession` to handle the user authentication flow. Native deep linking is not supported in "Expo Go". For more details please refer to [deep-linking](https://docs.expo.dev/guides/deep-linking/)
-> Use [development-build](https://docs.expo.dev/develop/development-builds/introduction/) to test this SDK on Android.
+#### For iOS
 
-Under the path `packages/rn-sample` run the following command.
+Customize the redirect URI e.g. `io.logto://callback` and pass it to the `signIn` function.
+
+Run the following command under the path `packages/rn-sample`.
 
 ```bash
 pnpm dev:ios
 ```
+
+#### For web
+
+Customize the redirect URI e.g. `http://localhost:19006` and pass it to the `signIn` function.
+
+Run the following command under the path `packages/rn-sample`.
+
+```bash
+pnpm dev:web
+```
+
+#### For Android
+
+> [!Caution]
+> This SDK is not compatible with "Expo Go" sandbox on Android.
+> Expo Go app by default uses `exp://` scheme for deep linking, which is not a valid private native scheme. See [OAuth2 spec](https://datatracker.ietf.org/doc/html/rfc8252#section-8.4) for more details.
+> For Android, Use [development-build](https://docs.expo.dev/develop/development-builds/introduction/) to test this SDK
+
+:::note
+
+In terms of the redirect URI scheme, different platforms have different requirements.
+
+- For native platforms, a Private-Use native URI scheme is required. See [OAuth2 spec](https://datatracker.ietf.org/doc/html/rfc8252#section-8.4) for more details.
+- For web platforms (SPA), an `http(s)//` scheme is required.
+
+You may need to register different applications in the Logto dashboard for different platforms. Make sure to configure the correct `redirectUri` and `clientId` for different platforms.
+
+:::
 
 ### Build and run native package
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ const App = () => {
 > In terms of the redirect URI scheme, different platforms have different requirements.
 >
 > - For native platforms, a Private-Use native URI scheme is required. See [OAuth2 spec](https://datatracker.ietf.org/doc/html/rfc8252#section-8.4) for more details.
-> - For web platforms (SPA), an `http(s)//` scheme is required.
+> - For web platforms (SPA), an `http(s)://` scheme is required.
 >
 > You may need to register different applications in the Logto dashboard for different platforms. Make sure to configure the correct `redirectUri` and `clientId` for different platforms.
 

--- a/README.md
+++ b/README.md
@@ -108,16 +108,13 @@ pnpm dev:web
 > Expo Go app by default uses `exp://` scheme for deep linking, which is not a valid private native scheme. See [OAuth2 spec](https://datatracker.ietf.org/doc/html/rfc8252#section-8.4) for more details.
 > For Android, Use [development-build](https://docs.expo.dev/develop/development-builds/introduction/) to test this SDK
 
-:::note
-
-In terms of the redirect URI scheme, different platforms have different requirements.
-
-- For native platforms, a Private-Use native URI scheme is required. See [OAuth2 spec](https://datatracker.ietf.org/doc/html/rfc8252#section-8.4) for more details.
-- For web platforms (SPA), an `http(s)//` scheme is required.
-
-You may need to register different applications in the Logto dashboard for different platforms. Make sure to configure the correct `redirectUri` and `clientId` for different platforms.
-
-:::
+> [!Note]
+> In terms of the redirect URI scheme, different platforms have different requirements.
+>
+> - For native platforms, a Private-Use native URI scheme is required. See [OAuth2 spec](https://datatracker.ietf.org/doc/html/rfc8252#section-8.4) for more details.
+> - For web platforms (SPA), an `http(s)//` scheme is required.
+>
+> You may need to register different applications in the Logto dashboard for different platforms. Make sure to configure the correct `redirectUri` and `clientId` for different platforms.
 
 ### Build and run native package
 

--- a/packages/rn-sample/App.tsx
+++ b/packages/rn-sample/App.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-unassigned-import
 import '@logto/rn/polyfill';
 
-import { LogtoProvider, useLogto, type IdTokenClaims } from '@logto/rn';
+import { LogtoProvider, Prompt, useLogto, type IdTokenClaims } from '@logto/rn';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect, useState } from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
@@ -54,6 +54,7 @@ const App = () => {
       config={{
         endpoint,
         appId,
+        prompt: Prompt.Login,
       }}
     >
       <Content />

--- a/packages/rn-sample/App.tsx
+++ b/packages/rn-sample/App.tsx
@@ -56,7 +56,7 @@ const App = () => {
         appId,
         // For better demonstration, override the default prompt to always show the login screen.
         // Default value is `Prompt.Consent`.
-        // With Prompt.Consent settings User will automatically be consented if they have a valid session.
+        // With `Prompt.Consent` settings, user will automatically be consented if they have a valid session.
         prompt: Prompt.Login,
       }}
     >

--- a/packages/rn-sample/App.tsx
+++ b/packages/rn-sample/App.tsx
@@ -54,6 +54,9 @@ const App = () => {
       config={{
         endpoint,
         appId,
+        // For better demonstration, override the default prompt to always show the login screen.
+        // Default value is `Prompt.Consent`.
+        // With Prompt.Consent settings User will automatically be consented if they have a valid session.
         prompt: Prompt.Login,
       }}
     >

--- a/packages/rn-sample/package.json
+++ b/packages/rn-sample/package.json
@@ -7,10 +7,12 @@
     "dev": "expo start",
     "dev:android": "expo start --android",
     "dev:ios": "expo start --ios",
+    "dev:web": "expo start --web",
     "android": "expo run:android",
     "ios": "expo run:ios"
   },
   "dependencies": {
+    "@expo/metro-runtime": "~3.1.3",
     "@logto/rn": "workspace:^",
     "@react-native-async-storage/async-storage": "^1.22.0",
     "expo": "~50.0.6",
@@ -19,7 +21,9 @@
     "expo-status-bar": "~1.11.1",
     "expo-web-browser": "^12.8.2",
     "react": "18.2.0",
-    "react-native": "0.73.4"
+    "react-dom": "18.2.0",
+    "react-native": "0.73.4",
+    "react-native-web": "~0.19.6"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/packages/rn/package.json
+++ b/packages/rn/package.json
@@ -62,6 +62,7 @@
     "@react-native-async-storage/async-storage": "^1.22.0",
     "expo-crypto": "^12.8.0",
     "expo-secure-store": "^12.8.1",
-    "expo-web-browser": "^12.8.2"
+    "expo-web-browser": "^12.8.2",
+    "react-native": "0.73.4"
   }
 }

--- a/packages/rn/src/client.ts
+++ b/packages/rn/src/client.ts
@@ -1,16 +1,17 @@
 import {
-  type LogtoConfig,
-  createRequester,
-  StandardLogtoClient,
-  type InteractionMode,
-  Prompt,
   LogtoError,
+  Prompt,
+  StandardLogtoClient,
+  createRequester,
+  type InteractionMode,
+  type LogtoConfig,
 } from '@logto/client/shim';
 import { decodeIdToken } from '@logto/js';
 import * as WebBrowser from 'expo-web-browser';
+import { Platform } from 'react-native';
 
 import { LogtoNativeClientError } from './errors';
-import { SecureStorage } from './storage';
+import { BrowserStorage, SecureStorage } from './storage';
 import { generateCodeChallenge, generateRandomString } from './utils';
 
 const issuedAtTimeTolerance = 300; // 5 minutes
@@ -39,10 +40,14 @@ export type LogtoNativeConfig = LogtoConfig & {
 
 export class LogtoClient extends StandardLogtoClient {
   authSessionResult?: WebBrowser.WebBrowserAuthSessionResult;
-  protected storage: SecureStorage;
+  protected storage: SecureStorage | BrowserStorage;
 
   constructor(config: LogtoNativeConfig) {
-    const storage = new SecureStorage(`logto.${config.appId}`);
+    const storage =
+      Platform.OS === 'web'
+        ? new BrowserStorage(config.appId)
+        : new SecureStorage(`logto.${config.appId}`);
+
     const requester = createRequester(fetch);
 
     super(

--- a/packages/rn/src/hooks.ts
+++ b/packages/rn/src/hooks.ts
@@ -1,4 +1,5 @@
-import { useCallback, useContext, useMemo } from 'react';
+import { maybeCompleteAuthSession } from 'expo-web-browser';
+import { useCallback, useContext, useEffect, useMemo } from 'react';
 
 // eslint-disable-next-line unused-imports/no-unused-imports -- use for JSDoc
 import type { LogtoClient } from './client';
@@ -11,6 +12,12 @@ import { LogtoContext } from './context';
  */
 export const useLogto = () => {
   const { client, isAuthenticated, setIsAuthenticated } = useContext(LogtoContext);
+
+  useEffect(() => {
+    // This is required to handle the redirect from the browser on a web-based expo app
+    // @see {@link https://docs.expo.dev/versions/latest/sdk/webbrowser/#webbrowsermaybecompleteauthsessionoptions}
+    maybeCompleteAuthSession();
+  }, []);
 
   const signIn = useCallback(
     async (redirectUri: string) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       js-base64:
         specifier: ^3.7.6
         version: 3.7.6
+      react-native:
+        specifier: 0.73.4
+        version: 0.73.4(@babel/core@7.23.9)(@babel/preset-env@7.23.9)(react@18.2.0)
     devDependencies:
       '@babel/preset-env':
         specifier: ^7.23.9
@@ -84,6 +87,9 @@ importers:
 
   packages/rn-sample:
     dependencies:
+      '@expo/metro-runtime':
+        specifier: ~3.1.3
+        version: 3.1.3(react-native@0.73.4)
       '@logto/rn':
         specifier: workspace:^
         version: link:../rn
@@ -108,9 +114,15 @@ importers:
       react:
         specifier: 18.2.0
         version: 18.2.0
+      react-dom:
+        specifier: 18.2.0
+        version: 18.2.0(react@18.2.0)
       react-native:
         specifier: 0.73.4
         version: 0.73.4(@babel/core@7.23.9)(@babel/preset-env@7.23.9)(react@18.2.0)
+      react-native-web:
+        specifier: ~0.19.6
+        version: 0.19.10(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@babel/core':
         specifier: ^7.20.0
@@ -2235,6 +2247,14 @@ packages:
       sucrase: 3.34.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /@expo/metro-runtime@3.1.3(react-native@0.73.4):
+    resolution: {integrity: sha512-u1CaQJJlSgvxBB5NJ6YMVvSDTTRzjT71dHpEBnKPZhpFv5ebVry52FZ2sEeEEA6mHG5zGxWXmHImW3hNKHh8EA==}
+    peerDependencies:
+      react-native: '*'
+    dependencies:
+      react-native: 0.73.4(@babel/core@7.23.9)(@babel/preset-env@7.23.9)(react@18.2.0)
     dev: false
 
   /@expo/osascript@2.1.0:
@@ -4505,6 +4525,12 @@ packages:
     engines: {node: '>=12 || >=16'}
     dev: true
 
+  /css-in-js-utils@3.1.0:
+    resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
+    dependencies:
+      hyphenate-style-name: 1.0.4
+    dev: false
+
   /css-tree@2.3.1:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
@@ -5683,6 +5709,10 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
 
+  /fast-loops@1.1.3:
+    resolution: {integrity: sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g==}
+    dev: false
+
   /fast-xml-parser@4.3.4:
     resolution: {integrity: sha512-utnwm92SyozgA3hhH2I8qldf2lBqm6qHOICawRNRFu1qMe3+oqr+GcXjGqTmXTMGE5T4eC03kr/rlh5C1IRdZA==}
     hasBin: true
@@ -6288,6 +6318,10 @@ packages:
     hasBin: true
     dev: true
 
+  /hyphenate-style-name@1.0.4:
+    resolution: {integrity: sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==}
+    dev: false
+
   /ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
     dev: false
@@ -6348,6 +6382,13 @@ packages:
 
   /ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  /inline-style-prefixer@6.0.4:
+    resolution: {integrity: sha512-FwXmZC2zbeeS7NzGjJ6pAiqRhXR0ugUShSNb6GApMl6da0/XGc4MOJsoWAywia52EEWbXNSy0pzkwz/+Y+swSg==}
+    dependencies:
+      css-in-js-utils: 3.1.0
+      fast-loops: 1.1.3
+    dev: false
 
   /internal-ip@4.3.0:
     resolution: {integrity: sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==}
@@ -7361,6 +7402,10 @@ packages:
 
   /memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
+    dev: false
+
+  /memoize-one@6.0.0:
+    resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
     dev: false
 
   /memory-cache@0.2.0:
@@ -8395,7 +8440,6 @@ packages:
 
   /postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-    dev: true
 
   /postcss@8.4.35:
     resolution: {integrity: sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==}
@@ -8581,6 +8625,16 @@ packages:
       - utf-8-validate
     dev: false
 
+  /react-dom@18.2.0(react@18.2.0):
+    resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
+    peerDependencies:
+      react: ^18.2.0
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.2.0
+      scheduler: 0.23.0
+    dev: false
+
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -8590,6 +8644,26 @@ packages:
 
   /react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
+
+  /react-native-web@0.19.10(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-IQoHiTQq8egBCVVwmTrYcFLgEFyb4LMZYEktHn4k22JMk9+QTCEz5WTfvr+jdNoeqj/7rtE81xgowKbfGO74qg==}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@react-native/normalize-color': 2.1.0
+      fbjs: 3.0.5
+      inline-style-prefixer: 6.0.4
+      memoize-one: 6.0.0
+      nullthrows: 1.1.1
+      postcss-value-parser: 4.2.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      styleq: 0.1.3
+    transitivePeerDependencies:
+      - encoding
+    dev: false
 
   /react-native@0.73.4(@babel/core@7.23.9)(@babel/preset-env@7.23.9)(react@18.2.0):
     resolution: {integrity: sha512-VtS+Yr6OOTIuJGDECIYWzNU8QpJjASQYvMtfa/Hvm/2/h5GdB6W9H9TOmh13x07Lj4AOhNMx3XSsz6TdrO4jIg==}
@@ -9010,6 +9084,12 @@ packages:
 
   /sax@1.3.0:
     resolution: {integrity: sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==}
+    dev: false
+
+  /scheduler@0.23.0:
+    resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
+    dependencies:
+      loose-envify: 1.4.0
     dev: false
 
   /scheduler@0.24.0-canary-efb381bbf-20230505:
@@ -9583,6 +9663,10 @@ packages:
       - supports-color
       - typescript
     dev: true
+
+  /styleq@0.1.3:
+    resolution: {integrity: sha512-3ZUifmCDCQanjeej1f6kyl/BeP/Vae5EYkQ9iJfUm/QwZvlgnZzyflqAsAWYURdtea8Vkvswu2GrC57h3qffcA==}
+    dev: false
 
   /sucrase@3.34.0:
     resolution: {integrity: sha512-70/LQEZ07TEcxiU2dz51FKaE6hCTWC6vr7FOk3Gr0U60C3shtAN+H+BFr9XlYe5xqf3RA8nrc+VIwzCfnxuXJw==}


### PR DESCRIPTION


<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add the expo web platform support, including the following major updates

- update the sample project to support expo web development
- add a new `BrowserStorage` (forked from @logto/browser SDK) to support web-based storage. As [expo-secure-store](https://docs.expo.dev/versions/latest/sdk/securestore/) only support native platforms. 
- add the `maybeCompleteAuthSession()` listener to the `useLogto` hook. This will redirect user from a popUp window back the web app.  


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<img width="1145" alt="image" src="https://github.com/logto-io/react-native/assets/36393111/6148588a-2bd9-45a8-b8e4-2fd3bdd23287">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [x] necessary TSDoc comments
