### PR TITLE
feat: update @logto/client

### DIFF
--- a/packages/rn-sample/metro.config.js
+++ b/packages/rn-sample/metro.config.js
@@ -21,6 +21,4 @@ config.resolver.nodeModulesPaths = [
   path.resolve(monorepoRoot, 'node_modules'),
 ];
 
-config.resolver.unstable_enablePackageExports = true;
-
 module.exports = config;

--- a/packages/rn/package.json
+++ b/packages/rn/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -49,8 +49,8 @@
   },
   "prettier": "@silverhand/eslint-config/.prettierrc",
   "dependencies": {
-    "@logto/client": "2.4.0",
-    "@logto/js": "4.0.0",
+    "@logto/client": "2.8.1",
+    "@logto/js": "4.2.0",
     "crypto-es": "^2.1.0",
     "js-base64": "^3.7.7"
   },

--- a/packages/rn/src/client.ts
+++ b/packages/rn/src/client.ts
@@ -3,9 +3,10 @@ import {
   Prompt,
   StandardLogtoClient,
   createRequester,
+  SignInOptions,
   type InteractionMode,
   type LogtoConfig,
-} from '@logto/client/shim';
+} from '@logto/client';
 import { decodeIdToken } from '@logto/js';
 import * as WebBrowser from 'expo-web-browser';
 import { Platform } from 'react-native';
@@ -111,14 +112,35 @@ export class LogtoClient extends StandardLogtoClient {
    * The user will be redirected to that URI after the sign-in flow is completed, and the client
    * will handle the callback to exchange the authorization code for the tokens.
    *
+   * @param options The options for the sign-in flow.
+   *
+   * @see {@link SignInOptions}
+   */
+  override async signIn(options: SignInOptions): Promise<void>;
+  /**
+   * Start the sign-in flow with the specified redirect URI. The URI must be registered in the
+   * Logto Console. It uses `WebBrowser.openAuthSessionAsync` to open the browser and start the
+   * sign-in flow.
+   *
+   * The user will be redirected to that URI after the sign-in flow is completed, and the client
+   * will handle the callback to exchange the authorization code for the tokens.
+   *
    * @param redirectUri The redirect URI that the user will be redirected to after the sign-in flow is completed.
    * @param interactionMode The interaction mode to be used for the authorization request. Note it's not
    * a part of the OIDC standard, but a Logto-specific extension. Defaults to `signIn`.
    *
    * @see {@link InteractionMode}
    */
-  override async signIn(redirectUri: string, interactionMode?: InteractionMode): Promise<void> {
-    await super.signIn(redirectUri, interactionMode);
+  override async signIn(redirectUri: string, interactionMode?: InteractionMode): Promise<void>;
+  override async signIn(
+    options: SignInOptions | string,
+    interactionMode?: InteractionMode
+  ): Promise<void> {
+    if (typeof options === 'string') {
+      await super.signIn(options, interactionMode);
+    } else {
+      await super.signIn(options);
+    }
 
     if (this.authSessionResult?.type !== 'success') {
       throw new LogtoNativeClientError('auth_session_failed');

--- a/packages/rn/src/client.ts
+++ b/packages/rn/src/client.ts
@@ -3,7 +3,7 @@ import {
   Prompt,
   StandardLogtoClient,
   createRequester,
-  SignInOptions,
+  type SignInOptions,
   type InteractionMode,
   type LogtoConfig,
 } from '@logto/client';
@@ -67,7 +67,6 @@ export class LogtoClient extends StandardLogtoClient {
             case 'sign-out': {
               break;
             }
-            // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- just in case
             default: {
               throw new LogtoNativeClientError('navigation_purpose_not_supported');
             }
@@ -136,11 +135,9 @@ export class LogtoClient extends StandardLogtoClient {
     options: SignInOptions | string,
     interactionMode?: InteractionMode
   ): Promise<void> {
-    if (typeof options === 'string') {
-      await super.signIn(options, interactionMode);
-    } else {
-      await super.signIn(options);
-    }
+    await (typeof options === 'string'
+      ? super.signIn(options, interactionMode)
+      : super.signIn(options));
 
     if (this.authSessionResult?.type !== 'success') {
       throw new LogtoNativeClientError('auth_session_failed');

--- a/packages/rn/src/hooks.ts
+++ b/packages/rn/src/hooks.ts
@@ -1,3 +1,4 @@
+import { type InteractionMode, type SignInOptions } from '@logto/client';
 import { maybeCompleteAuthSession } from 'expo-web-browser';
 import { useCallback, useContext, useEffect, useMemo } from 'react';
 
@@ -19,9 +20,15 @@ export const useLogto = () => {
     maybeCompleteAuthSession();
   }, []);
 
-  const signIn = useCallback(
-    async (redirectUri: string) => {
-      await client.signIn(redirectUri);
+  const signIn: {
+    (options: string, interactionMode?: InteractionMode): Promise<void>;
+    (options: SignInOptions): Promise<void>;
+  } = useCallback(
+    async (options: SignInOptions | string, interactionMode?: InteractionMode) => {
+      await (typeof options === 'string'
+        ? client.signIn(options, interactionMode)
+        : client.signIn(options));
+
       setIsAuthenticated(true);
     },
     [client, setIsAuthenticated]

--- a/packages/rn/src/index.ts
+++ b/packages/rn/src/index.ts
@@ -6,7 +6,7 @@ export type {
   UserInfoResponse,
   InteractionMode,
   ClientAdapter,
-} from '@logto/client/shim';
+} from '@logto/client';
 
 export {
   createRequester,
@@ -22,7 +22,7 @@ export {
   buildOrganizationUrn,
   getOrganizationIdFromUrn,
   PersistKey,
-} from '@logto/client/shim';
+} from '@logto/client';
 
 export * from './client';
 export * from './context';

--- a/packages/rn/src/storage.ts
+++ b/packages/rn/src/storage.ts
@@ -1,4 +1,4 @@
-import { type Storage, type StorageKey } from '@logto/client/shim';
+import { type Storage, type StorageKey } from '@logto/client';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { Nullable } from '@silverhand/essentials';
 import CryptoES from 'crypto-es';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,11 +28,11 @@ importers:
   packages/rn:
     dependencies:
       '@logto/client':
-        specifier: 2.4.0
-        version: 2.4.0
+        specifier: 2.8.1
+        version: 2.8.1
       '@logto/js':
-        specifier: 4.0.0
-        version: 4.0.0
+        specifier: 4.2.0
+        version: 4.2.0
       '@react-native-async-storage/async-storage':
         specifier: ^1.23.1
         version: 1.23.1(react-native@0.74.1(@babel/core@7.24.4)(@babel/preset-env@7.24.4(@babel/core@7.24.4))(@types/react@18.2.55)(react@18.2.0))
@@ -136,7 +136,7 @@ importers:
         version: 6.0.1(eslint@8.57.0)(prettier@3.2.5)(typescript@5.4.5)
       '@silverhand/eslint-config-react':
         specifier: ^6.0.2
-        version: 6.0.2(eslint@8.57.0)(postcss@8.4.35)(prettier@3.2.5)(stylelint@15.11.0(typescript@5.4.5))(typescript@5.4.5)
+        version: 6.0.2(eslint@8.57.0)(postcss@8.4.38)(prettier@3.2.5)(stylelint@15.11.0(typescript@5.4.5))(typescript@5.4.5)
       '@types/react':
         specifier: ~18.2.79
         version: 18.2.79
@@ -1298,6 +1298,7 @@ packages:
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -1305,6 +1306,7 @@ packages:
 
   '@humanwhocodes/object-schema@2.0.2':
     resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
+    deprecated: Use @eslint/object-schema instead
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -1359,11 +1361,11 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@logto/client@2.4.0':
-    resolution: {integrity: sha512-gdswqI5yuov7H/8SU2GoFDKRrlwTbhhRleq2Pnf5Yphq+Kvggu7j7EsixGE97QzomPfe2x8eeWtWoHyI96Q5qA==}
+  '@logto/client@2.8.1':
+    resolution: {integrity: sha512-tUQC36l9U3knrTicXFjd+FiBqwG1/KSGn1o3wx9DFn+5iSTQa66B+Y88GaXcxAYsgjzmSHrDY3qxuQg729mleQ==}
 
-  '@logto/js@4.0.0':
-    resolution: {integrity: sha512-eKLS0HqFjQyf7imKTf2a7FUmMuNeebxFZ2b5A/1qUWSyO+BIxSu0XYI4JZ9qjtWNPvlGmL+jPOkIUuWQ9DZYZw==}
+  '@logto/js@4.2.0':
+    resolution: {integrity: sha512-kse29kNKuM/tw30YcOf2eOQuFBlGPZTr4rKI/LpdTKhk0fLGM5ZJKPQWNPiPFZdBfTldERXVNtd17/bZLWc/OQ==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1607,9 +1609,9 @@ packages:
     peerDependencies:
       eslint: ^8.1.0
 
-  '@silverhand/essentials@2.9.0':
-    resolution: {integrity: sha512-n9mSO/gsLj0GRFXBRNhaQLRK6qbn6pBnKjMQdFwweKgT12ODBXpgkpXohpOBqSofnoaCQWqiDAT6xpCy/5dMIg==}
-    engines: {node: ^18.12.0 || ^20.9.0, pnpm: ^8.0.0}
+  '@silverhand/essentials@2.9.1':
+    resolution: {integrity: sha512-rsql/ZxXMqVvt7ySDHd7xjCog4oCYg+dexxlj3veolajwjKiy/08ZtFyEtFjSEAaKbXwkWZ4TDtiNSxb7HS0yA==}
+    engines: {node: ^18.12.0 || ^20.9.0, pnpm: ^9.0.0}
 
   '@silverhand/ts-config-react@6.0.0':
     resolution: {integrity: sha512-eEB8TwGzw5kJTKcuHtvifpcs6p8ZDNRFWH2W7ZM4Rf7DsFBQtXkYpwQFQvZ9UVOAs4YCIeSY4OJCjtaY0fUp8g==}
@@ -3175,12 +3177,15 @@ packages:
 
   glob@6.0.4:
     resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   global-dirs@0.1.1:
     resolution: {integrity: sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==}
@@ -3375,6 +3380,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -3679,8 +3685,8 @@ packages:
   join-component@1.1.0:
     resolution: {integrity: sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==}
 
-  jose@5.2.2:
-    resolution: {integrity: sha512-/WByRr4jDcsKlvMd1dRJnPfS1GVO3WuKyaurJ/vvXcOaUQO8rnNObCQMlv/5uCceVQIq5Q4WLF44ohsdiTohdg==}
+  jose@5.9.2:
+    resolution: {integrity: sha512-ILI2xx/I57b20sd7rHZvgiiQrmp2mcotwsAH+5ajbpFQbrYVQdNHYlQhoA5cFb78CgtBOxtC05TeA+mcgkuCqQ==}
 
   js-base64@3.7.7:
     resolution: {integrity: sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==}
@@ -4396,6 +4402,7 @@ packages:
 
   osenv@0.1.5:
     resolution: {integrity: sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==}
+    deprecated: This package is no longer supported.
 
   p-finally@1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
@@ -4864,18 +4871,22 @@ packages:
 
   rimraf@2.4.5:
     resolution: {integrity: sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@2.6.3:
     resolution: {integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rollup@4.14.3:
@@ -7401,16 +7412,16 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  '@logto/client@2.4.0':
+  '@logto/client@2.8.1':
     dependencies:
-      '@logto/js': 4.0.0
-      '@silverhand/essentials': 2.9.0
+      '@logto/js': 4.2.0
+      '@silverhand/essentials': 2.9.1
       camelcase-keys: 7.0.2
-      jose: 5.2.2
+      jose: 5.9.2
 
-  '@logto/js@4.0.0':
+  '@logto/js@4.2.0':
     dependencies:
-      '@silverhand/essentials': 2.9.0
+      '@silverhand/essentials': 2.9.1
       camelcase-keys: 7.0.2
 
   '@nodelib/fs.scandir@2.1.5':
@@ -7834,6 +7845,27 @@ snapshots:
       - supports-color
       - typescript
 
+  '@silverhand/eslint-config-react@6.0.2(eslint@8.57.0)(postcss@8.4.38)(prettier@3.2.5)(stylelint@15.11.0(typescript@5.4.5))(typescript@5.4.5)':
+    dependencies:
+      '@silverhand/eslint-config': 6.0.1(eslint@8.57.0)(prettier@3.2.5)(typescript@5.4.5)
+      eslint-config-xo-react: 0.27.0(eslint-plugin-react-hooks@4.6.0(eslint@8.57.0))(eslint-plugin-react@7.34.1(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
+      eslint-plugin-react: 7.34.1(eslint@8.57.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
+      postcss-scss: 4.0.9(postcss@8.4.38)
+      stylelint: 15.11.0(typescript@5.4.5)
+      stylelint-config-xo: 0.22.0(stylelint@15.11.0(typescript@5.4.5))
+      stylelint-scss: 6.2.1(stylelint@15.11.0(typescript@5.4.5))
+    transitivePeerDependencies:
+      - '@types/eslint'
+      - eslint
+      - eslint-import-resolver-node
+      - eslint-import-resolver-webpack
+      - postcss
+      - prettier
+      - supports-color
+      - typescript
+
   '@silverhand/eslint-config@6.0.1(eslint@8.57.0)(prettier@3.2.5)(typescript@5.4.5)':
     dependencies:
       '@silverhand/eslint-plugin-fp': 2.5.0(eslint@8.57.0)
@@ -7843,10 +7875,10 @@ snapshots:
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
       eslint-config-xo: 0.44.0(eslint@8.57.0)
       eslint-config-xo-typescript: 4.0.0(@typescript-eslint/eslint-plugin@7.7.0(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-consistent-default-export-name: 0.0.15
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-n: 17.2.1(eslint@8.57.0)
       eslint-plugin-no-use-extend-native: 0.5.0
       eslint-plugin-prettier: 5.1.3(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.2.5)
@@ -7870,7 +7902,7 @@ snapshots:
       import-modules: 2.1.0
       lodash: 4.17.21
 
-  '@silverhand/essentials@2.9.0': {}
+  '@silverhand/essentials@2.9.1': {}
 
   '@silverhand/ts-config-react@6.0.0(typescript@5.4.5)':
     dependencies:
@@ -9157,13 +9189,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -9174,14 +9206,14 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.7.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9203,7 +9235,7 @@ snapshots:
       eslint: 8.57.0
       ignore: 5.3.1
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.4
@@ -9213,7 +9245,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.1
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -10279,7 +10311,7 @@ snapshots:
 
   join-component@1.1.0: {}
 
-  jose@5.2.2: {}
+  jose@5.9.2: {}
 
   js-base64@3.7.7: {}
 
@@ -11226,6 +11258,10 @@ snapshots:
   postcss-scss@4.0.9(postcss@8.4.35):
     dependencies:
       postcss: 8.4.35
+
+  postcss-scss@4.0.9(postcss@8.4.38):
+    dependencies:
+      postcss: 8.4.38
 
   postcss-selector-parser@6.0.15:
     dependencies:


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Bump `@logto/client` version to pick up the following updates:

1.  Removed the conditional `shim` exports entry point.  `unstable_enablePackageExports` setting in Metro is no longer needed, as it was causing issues with other packages.  Check this [PR](https://github.com/logto-io/js/pull/791) for more details.
2. Enable all the latest sign-in options including `firstScreen`, `loginHint`, `extraParams`, and `identifiers`. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
