### PR TITLE
fix: open browser window with `createTask: false`.

### DIFF
--- a/packages/rn/src/client.ts
+++ b/packages/rn/src/client.ts
@@ -61,6 +61,7 @@ export class LogtoClient extends StandardLogtoClient {
               this.authSessionResult = undefined;
               this.authSessionResult = await WebBrowser.openAuthSessionAsync(url, redirectUri, {
                 preferEphemeralSession: config.preferEphemeralSession ?? true,
+                createTask: false
               });
               break;
             }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Added `createTask: false` to the browser window being opened to open the browser window within the same activity the user is in. This prevents the activity from getting closed and from multiple browser tabs being opened and staying unclosed.


<!-- MANDATORY -->
## Testing
Tested locally


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
