### PR TITLE
fix: allow Expo SDK 54 peer deps

### DIFF
--- a/packages/rn/package.json
+++ b/packages/rn/package.json
@@ -56,9 +56,9 @@
   },
   "peerDependencies": {
     "@react-native-async-storage/async-storage": "^1.23.1",
-    "expo-crypto": "^14.0.2",
-    "expo-secure-store": "^14.0.1",
-    "expo-web-browser": "^14.0.2",
+    "expo-crypto": ">=14.0.2 <16",
+    "expo-secure-store": ">=14.0.1 <16",
+    "expo-web-browser": ">=14.0.2 <16",
     "react-native": ">=0.76.0 <1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,13 +58,13 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       expo-crypto:
-        specifier: ^14.0.2
+        specifier: '>=14.0.2 <16'
         version: 14.0.2(expo@52.0.46(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@18.2.79)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@18.2.79)(react@18.3.1))(react@18.3.1))
       expo-secure-store:
-        specifier: ^14.0.1
+        specifier: '>=14.0.1 <16'
         version: 14.0.1(expo@52.0.46(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@18.2.79)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@18.2.79)(react@18.3.1))(react@18.3.1))
       expo-web-browser:
-        specifier: ^14.0.2
+        specifier: '>=14.0.2 <16'
         version: 14.0.2(expo@52.0.46(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@18.2.79)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@18.2.79)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@18.2.79)(react@18.3.1))
       js-base64:
         specifier: ^3.7.7


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- Expand expo-crypto, expo-secure-store, and expo-web-browser peer ranges to include 15.x.
- Keep compatibility with existing 14.x Expo SDKs.
Resolves [issue#55](https://github.com/logto-io/react-native/issues/55).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
