### PR TITLE
fix(deps): updating expo peerDependency to < 56 to match with new specs for Expo version

### DIFF
--- a/packages/rn/package.json
+++ b/packages/rn/package.json
@@ -61,9 +61,9 @@
   },
   "peerDependencies": {
     "@react-native-async-storage/async-storage": ">=1.23.1 <3",
-    "expo-crypto": ">=14.0.2 <16",
-    "expo-secure-store": ">=14.0.1 <16",
-    "expo-web-browser": ">=14.0.2 <16",
+    "expo-crypto": ">=14.0.2 <56",
+    "expo-secure-store": ">=14.0.1 <56",
+    "expo-web-browser": ">=14.0.2 <56",
     "react-native": ">=0.76.0 <1"
   }
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
- Updating `peerDependencies` to match the Expo 55 new convention to publish all packages matching Expo SDK: https://expo.dev/changelog/sdk-55#new-expo-sdk-package-versioning-scheme, as of today new app built with Expo cannot install the library since it's locked to use Expo versions below < **16**
<!-- Provide detailed PR description below -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
